### PR TITLE
Implement a Metadata type

### DIFF
--- a/packages/react/src/fetch.ts
+++ b/packages/react/src/fetch.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { Metadata } from "./metadata";
+
 export type MessageLevel = "info" | "success" | "warning" | "error";
 
 export interface TextMessage {
@@ -26,7 +28,7 @@ interface RedirectResponse {
 interface RenderResponse {
   status: "render";
   overlay: boolean;
-  title: string;
+  metadata: Metadata;
   view: string;
   props: Record<string, unknown>;
   context: Record<string, unknown>;

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement, ReactNode } from "react";
 
 import Browser from "./components/Browser";
 import { Message, DjangoBridgeResponse, djangoGet } from "./fetch";
+import { Metadata } from "./metadata";
 import { Frame, useNavigationController } from "./navigation";
 import { DirtyFormScope } from "./dirtyform";
 import Link, { BuildLinkElement, buildLinkElement } from "./components/Link";
@@ -196,7 +197,7 @@ export { DirtyFormContext, DirtyFormMarker } from "./dirtyform";
 export type { DirtyForm } from "./dirtyform";
 export { type NavigationController } from "./navigation";
 export type { Frame } from "./navigation";
-export type { DjangoBridgeResponse as Response };
+export type { DjangoBridgeResponse as Response, Metadata };
 export { Link, BuildLinkElement, buildLinkElement };
 export type { Message };
 export { Config };

--- a/packages/react/src/metadata.ts
+++ b/packages/react/src/metadata.ts
@@ -1,0 +1,3 @@
+export interface Metadata {
+  title: string;
+}

--- a/packages/react/src/navigation.ts
+++ b/packages/react/src/navigation.ts
@@ -2,13 +2,14 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { djangoGet, djangoPost, DjangoBridgeResponse, Message } from "./fetch";
+import { Metadata } from "./metadata";
 
 let nextFrameId = 1;
 
 export interface Frame<Props = Record<string, unknown>> {
   id: number;
   path: string;
-  title: string;
+  metadata: Metadata;
   view: string;
   props: Props;
   context: Record<string, unknown>;
@@ -55,7 +56,9 @@ export function useNavigationController(
   const [currentFrame, setCurrentFrame] = useState<Frame>({
     id: nextFrameId,
     path: initialPath,
-    title: "Loading",
+    metadata: {
+      title: "Loading",
+    },
     view: "loading",
     props: {},
     context: {},
@@ -64,7 +67,7 @@ export function useNavigationController(
   const pushFrame = useCallback(
     (
       path: string,
-      title: string,
+      metadata: Metadata,
       view: string,
       props: Record<string, unknown>,
       context: Record<string, unknown>,
@@ -81,7 +84,7 @@ export function useNavigationController(
       }
 
       if (!parent) {
-        document.title = title;
+        document.title = metadata.title;
 
         if (pushState) {
           let scollPositionY = 0;
@@ -110,7 +113,7 @@ export function useNavigationController(
       const nextFrame = {
         id: frameId,
         path,
-        title,
+        metadata,
         view,
         props,
         context,
@@ -169,7 +172,7 @@ export function useNavigationController(
 
         pushFrame(
           path,
-          response.title,
+          response.metadata,
           response.view,
           props,
           context,

--- a/python/django_bridge/metadata.py
+++ b/python/django_bridge/metadata.py
@@ -1,0 +1,5 @@
+from typing import TypedDict
+
+
+class Metadata(TypedDict):
+    title: str

--- a/python/django_bridge/middleware.py
+++ b/python/django_bridge/middleware.py
@@ -69,10 +69,12 @@ class DjangoBridgeMiddleware:
                 )
 
             # Wrap the response with our bootstrap template
+            initial_response = json.loads(response.content.decode("utf-8"))
             new_response = render(
                 request,
                 "django_bridge/bootstrap.html",
                 {
+                    "metadata": initial_response.get("metadata"),
                     "initial_response": json.loads(response.content.decode("utf-8")),
                     "js": js,
                     "css": css,

--- a/python/django_bridge/templates/django_bridge/bootstrap.html
+++ b/python/django_bridge/templates/django_bridge/bootstrap.html
@@ -5,7 +5,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>{% block title %}{% endblock %}</title>
+  <title>{% block title %}{{ metadata.title }}{% endblock %}</title>
 
   {% for src in css %}
   <link href="{% static src %}" rel="stylesheet" />

--- a/python/django_bridge/test.py
+++ b/python/django_bridge/test.py
@@ -4,6 +4,7 @@ from django.test import TestCase as DjangoTestCase
 BOUNDARY = "BoUnDaRyStRiNg"
 MULTIPART_CONTENT = "multipart/form-data; boundary=%s" % BOUNDARY
 
+
 class Client(DjangoClient):
     def get(
         self, path, data=None, secure=False, *, headers=None, query_params=None, **extra

--- a/python/django_bridge/views.py
+++ b/python/django_bridge/views.py
@@ -1,18 +1,30 @@
+import warnings
 from django.views.generic.base import ContextMixin, View
 
 from .response import Response
-
+from .metadata import Metadata
 
 class DjangoBridgeMixin:
     """A mixin that can be used to render a view with a React component."""
 
     title = None
+    metadata = None
     view_name = None
     overlay = False
     response_class = Response
 
     def get_title(self):
+        if self.title:
+            warnings.warn(
+                "The title attribute is deprecated. Use metadata instead.",
+                PendingDeprecationWarning,
+            )
         return self.title
+
+    def get_metadata(self):
+        if not self.metadata:
+            return Metadata(title=self.get_title())
+        return self.metadata
 
     def render_to_response(self, props):
         """
@@ -26,7 +38,7 @@ class DjangoBridgeMixin:
             self.view_name,
             props,
             overlay=self.overlay,
-            title=self.title,
+            metadata=self.get_metadata(),
         )
 
 

--- a/website/docs/views.md
+++ b/website/docs/views.md
@@ -20,7 +20,17 @@ from django_bridge.response import Response
 
 def current_datetime(request):
     now = datetime.datetime.now()
-    return Response(request, “CurrentTime”, {“time” now})
+
+    return Response(
+        request,
+        “CurrentTime”,
+        {
+            “time”: now
+        },
+        metadata={
+            "title": "Current time"
+        }
+    )
 ```
 
 Let’s step through this code one line at a time:
@@ -31,7 +41,7 @@ Let’s step through this code one line at a time:
 
   Note that the name of the view function doesn’t matter; it doesn’t have to be named in a certain way in order for Django to recognize it. We’re calling it current_datetime here, because that name clearly indicates what it does.
 
-- The view returns an Response object that contains the name of the frontend component to render (“CurrentTime”) and the props to pass in to it. We will look at what this component looks like in the next section.
+- The view returns an Response object that contains the name of the frontend component to render (“CurrentTime”), the props to pass in to it, and some metadata which includes the page title. We will look at what this component looks like in the next section.
 
 ## Adding views to your URL config
 


### PR DESCRIPTION
This PR implements a way to set metadata values in the response. I've so far only added the ``title`` to this as that's the only metadata value supported by our React library. This API will allow us to support more Metadata for users of Next.js