### PR TITLE
RenderFrame component

### DIFF
--- a/packages/react/src/components/Browser.tsx
+++ b/packages/react/src/components/Browser.tsx
@@ -8,6 +8,7 @@ import {
   NavigationContext,
 } from "../contexts";
 import Config from "../config";
+import RenderFrame from "./RenderFrame";
 
 export interface BrowserProps {
   config: Config;
@@ -65,26 +66,13 @@ function Browser({
       refreshProps,
     ]
   );
-  // Get the view component
-  const View = config.views.get(currentFrame.view);
-  if (!View) {
-    return <p>Unknown view &apos;{currentFrame.view}&apos;</p>;
-  }
-
-  // Render the view and wrap it with each configured global context provider
-  let view = <View {...currentFrame.props} />;
-  config.contextProviders.forEach((provider, name) => {
-    view = (
-      <provider.Provider value={currentFrame.context[name]}>
-        {view}
-      </provider.Provider>
-    );
-  });
 
   // eslint-disable-next-line react/jsx-no-useless-fragment
   return (
     <NavigationContext.Provider value={NavigationUtils}>
-      <div key={currentFrame.id}>{view}</div>
+      <div key={currentFrame.id}>
+        <RenderFrame config={config} frame={currentFrame} />
+      </div>
     </NavigationContext.Provider>
   );
 }

--- a/packages/react/src/components/RenderFrame.tsx
+++ b/packages/react/src/components/RenderFrame.tsx
@@ -1,0 +1,30 @@
+import React, { ReactElement } from "react";
+
+import Config from "../config";
+import { Frame } from "../navigation";
+
+export interface RenderFrameProps {
+  config: Config;
+  frame: Frame;
+}
+
+function RenderFrame({ config, frame }: RenderFrameProps): ReactElement {
+  // Get the view component
+  const View = config.views.get(frame.view);
+  if (!View) {
+    return <p>Unknown view &apos;{frame.view}&apos;</p>;
+  }
+
+  // Render the view and wrap it with each configured global context provider
+  let view = <View {...frame.props} />;
+  config.contextProviders.forEach((provider, name) => {
+    view = (
+      <provider.Provider value={frame.context[name]}>{view}</provider.Provider>
+    );
+  });
+
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  return <div key={frame.id}>{view}</div>;
+}
+
+export default RenderFrame;

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -10,6 +10,7 @@ import Config from "./config";
 import Form from "./components/Form";
 import { MessagesContext } from "./contexts";
 import Overlay from "./components/Overlay";
+import RenderFrame from "./components/RenderFrame";
 
 export interface AppProps {
   config: Config;
@@ -202,3 +203,4 @@ export { Link, BuildLinkElement, buildLinkElement };
 export type { Message };
 export { Config };
 export { Form };
+export { RenderFrame };


### PR DESCRIPTION
Adds a ``RenderFrame`` component that can be used to render a response on its own without hooking up Django Render's own navigation utilities (better to use Next.js's own `<Link>` in Next.js so all other client-side routes work).

To use, add this file in your project under ``app/[[...slug]]/page.jsx``

```jsx
import { Metadata } from "next";
import { Config, Response, RenderFrame } from "../../../django-render/packages/core/src";
import HomeView from "../../views/HomeView";

const config = new Config();

// Add your views here
config.addView("JobSearch", HomeView);

export interface Props {
  params: { slug: string[] | undefined };
  searchParams?: Record<string, string>;
}

function getPath({ params, searchParams }: Props): string {
  let path = params.slug ? `${params.slug.join("/")}/` : "";
  if (searchParams) {
    const search = new URLSearchParams(searchParams).toString();

    if (search) {
      path += `?${search.toString()}`;
    }
  }

  return path;
};

async function getData(path: string): Promise<Response> {
  const res = await fetch(`${process.env.SERVER_URL}/${path}`, {
    cache: "no-store",
    headers: {
      'Accept': 'application/json',
      'X-Requested-With': 'DjangoRender'
    }
  })
  if (!res.ok) {
    // This will activate the closest `error.js` Error Boundary
    throw new Error('Failed to fetch data')
  }
  return config.unpack(await res.json()) as unknown as Response;
}

export async function generateMetadata(props: Props): Promise<Metadata> {
  const response = await getData(getPath(props));

  if (response.status !== "render") {
    return {};
  }

  return response.metadata;
}

export default async function Page(props: Props) {
  const path = getPath(props);
  const response = await getData(path);

  if (response.status === "render") {
    return (
      <RenderFrame config={config} frame={{
        id: 0,
        path,
        metadata: response.metadata,
        view: response.view,
        props: response.props,
        context: response.context,
      }} />
    );
  }
}

export const runtime = 'edge'
```
