### PR TITLE
Fix: info message level

### DIFF
--- a/packages/react/src/fetch.ts
+++ b/packages/react/src/fetch.ts
@@ -1,12 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+export type MessageLevel = "info" | "success" | "warning" | "error";
+
 export interface TextMessage {
-  level: "success" | "warning" | "error";
+  level: MessageLevel;
   text: string;
 }
 
 export interface HTMLMessage {
-  level: "success" | "warning" | "error";
+  level: MessageLevel;
   html: string;
 }
 

--- a/python/django_bridge/response.py
+++ b/python/django_bridge/response.py
@@ -9,15 +9,10 @@ from .adapters.registry import JSContext
 
 
 def get_messages(request):
+    default_level_tag = messages.DEFAULT_TAGS[messages.SUCCESS]
     return [
         {
-            "level": (
-                "error"
-                if message.level == messages.ERROR
-                else "warning"
-                if message.level == messages.WARNING
-                else "success"
-            ),
+            "level": messages.DEFAULT_TAGS.get(message.level, default_level_tag),
             "html": conditional_escape(message.message),
         }
         for message in messages.get_messages(request)


### PR DESCRIPTION
The current implementation maps `info` level messages to `success`, while `info` is a pre-defined level (built-in)
(see https://github.com/django/django/blob/main/django/contrib/messages/constants.py)

This small PR fixes handling `info` level messages as well
-> updated the .ts type for `Message`