### PR TITLE
Fix history state duplicating on page load

### DIFF
--- a/packages/react/src/navigation.ts
+++ b/packages/react/src/navigation.ts
@@ -290,7 +290,7 @@ export function useNavigationController(
   useEffect(() => {
     // Load initial response
     // eslint-disable-next-line no-void
-    void handleResponse(initialResponse, initialPath);
+    void handleResponse(initialResponse, initialPath, false); 
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {

--- a/packages/react/src/navigation.ts
+++ b/packages/react/src/navigation.ts
@@ -290,7 +290,7 @@ export function useNavigationController(
   useEffect(() => {
     // Load initial response
     // eslint-disable-next-line no-void
-    void handleResponse(initialResponse, initialPath, false); 
+    void handleResponse(initialResponse, initialPath, false);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {


### PR DESCRIPTION
Fixes #60 

This fixes an issue where on a page load, `handleResponse` is called, causing a copy of the current page to be added to the history stack. This would result in the first click of the back button to seemingly do nothing.