### PR TITLE
Move telepath and common to devDependencies

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -26,15 +26,15 @@
     ]
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "telepath-unpack": "^0.0.4",
-    "@django-bridge/common": "*"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@types/node": "^12.0.0",
     "@types/react": "18",
     "tsup": "^8.0.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "telepath-unpack": "^0.0.4",
+    "@django-bridge/common": "*"
   },
   "peerDependencies": {
     "react": "^18.2.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -26,15 +26,15 @@
     ]
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "telepath-unpack": "^0.0.4",
-    "@django-bridge/common": "*"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@types/node": "^12.0.0",
     "@types/react": "18",
     "tsup": "^8.0.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "telepath-unpack": "^0.0.4",
+    "@django-bridge/common": "*"
   },
   "peerDependencies": {
     "react": "^18.2.0"


### PR DESCRIPTION
This is to bundle them with the `@django-bridge/react` and `@django-bridge/next` packages