### PR TITLE
Move bundled modules to devDependencies

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,5 +38,7 @@ module.exports = {
     "react/require-default-props": "off",
     // By default, this rule also forbids quote characters which aren't very harmful
     "react/no-unescaped-entities": ["error", { forbid: [">", "}"] }],
+    // Allow imports from devDependencies. This allows @django-bridge/common to be imported
+    "import/no-extraneous-dependencies": ["error", { devDependencies: true }],
   },
 };

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -26,15 +26,15 @@
     ]
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "telepath-unpack": "^0.0.4",
-    "@django-bridge/common": "*"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@types/node": "^12.0.0",
     "@types/react": "18",
     "tsup": "^8.0.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "telepath-unpack": "^0.0.4",
+    "@django-bridge/common": "*"
   },
   "peerDependencies": {
     "react": "^18.2.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -26,15 +26,15 @@
     ]
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "telepath-unpack": "^0.0.4",
-    "@django-bridge/common": "*"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@types/node": "^12.0.0",
     "@types/react": "18",
     "tsup": "^8.0.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "telepath-unpack": "^0.0.4",
+    "@django-bridge/common": "*"
   },
   "peerDependencies": {
     "react": "^18.2.0"


### PR DESCRIPTION
These modules are bundled into `@django-bridge/react` and `@django-bridge/next` but because they're in the "dependencies" section of package.json, projects will try to install them.