### PR TITLE
Improve file encoding

### DIFF
--- a/python/django_bridge/adapters/forms.py
+++ b/python/django_bridge/adapters/forms.py
@@ -2,6 +2,8 @@ from datetime import date, datetime, time
 
 from django import forms
 
+from django.core.files import File
+
 from .registry import Adapter, register, registry
 
 
@@ -32,6 +34,10 @@ class FieldAdapter(Adapter):
 
         if isinstance(value, (datetime, date, time)):
             value = value.isoformat()
+
+        # Pack any file simply as a string that contains its path
+        if isinstance(value, File):
+            value = str(value)
 
         return (
             "forms.Field",


### PR DESCRIPTION
The current implementation packs files as a byte array, this is somewhat cumbersome to work with on the client-side, for instance when using a [`ClearableFileInput`](https://docs.djangoproject.com/en/5.2/ref/forms/widgets/#clearablefileinput).

Simply having the path available is usually sufficient and faster, for example when working with an `ImageField` that has a previously selected image.

This PR introduces a small adjustment: update the form adapter to pack any file simply as a `string` that contains its path
