### PR TITLE
Fix for forms with a prefix

### DIFF
--- a/python/django_bridge/adapters/forms.py
+++ b/python/django_bridge/adapters/forms.py
@@ -60,8 +60,10 @@ class FormAdapter(Adapter):
     js_constructor = "forms.Form"
 
     def js_args(self, form):
+        def field_with_name(field):
+            return FieldWithName(field.html_name, field)
         return [
-            [FieldWithName(name, form[name]) for name in form.fields.keys()],
+            [field_with_name(form[name]) for name in form.fields.keys()],
             form.errors,
         ]
 

--- a/python/django_bridge/adapters/test_forms.py
+++ b/python/django_bridge/adapters/test_forms.py
@@ -1,0 +1,32 @@
+from django.forms import Form, CharField
+from .forms import FormAdapter
+from django.test import TestCase
+
+
+class TestForm(Form):
+    test_field_a = CharField(initial='foo')
+    test_field_b = CharField(initial='bar')
+    test_field_c = CharField(initial='test')
+
+
+class TestFormAdapter(TestCase):
+
+    def test_form_without_prefix(self):
+        test_form = TestForm()
+        adapter = FormAdapter()
+        fields, errors = adapter.js_args(test_form)
+        self.assertEqual(len(fields), 3)
+        self.assertEqual(fields[0].name, "test_field_a")
+        self.assertEqual(fields[1].name, "test_field_b")
+        self.assertEqual(fields[2].name, "test_field_c")
+        self.assertEqual(errors, {})
+
+    def test_form_with_prefix(self):
+        test_form = TestForm(prefix="test_prefix")
+        adapter = FormAdapter()
+        fields, errors = adapter.js_args(test_form)
+        self.assertEqual(len(fields), 3)
+        self.assertEqual(fields[0].name, "test_prefix-test_field_a")
+        self.assertEqual(fields[1].name, "test_prefix-test_field_b")
+        self.assertEqual(fields[2].name, "test_prefix-test_field_c")
+        self.assertEqual(errors, {})


### PR DESCRIPTION
This PR fixes a small issue that the current `FormAdapter` class has with forms that have a `prefix` defined (used in e.g. form sets, see https://docs.djangoproject.com/en/5.2/ref/forms/api/#django.forms.Form.prefix)

- This small proposed change switches to using the `html_name` field attribute (instead of `name`) which takes the prefix value into account (as documented [here](https://docs.djangoproject.com/en/5.2/ref/forms/api/#django.forms.BoundField.html_name))

- Unit tests included