### PR TITLE
Fix #94: Implement useAutoRefresh hook

### DIFF
--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -1,0 +1,33 @@
+import React from "react";
+import { NavigationContext } from "./contexts";
+
+export type Timer = ReturnType<typeof setTimeout>;
+
+export function useAutoRefresh(enabled: boolean, interval: number) {
+  const { refreshProps } = React.useContext(NavigationContext);
+
+  React.useEffect(() => {
+    if (!enabled) {
+      return () => {};
+    }
+
+    let timeout: Timer | null = null;
+
+    const scheduleRefreshProps = () => {
+      timeout = setTimeout(() => {
+        // eslint-disable-next-line no-void
+        void refreshProps();
+
+        scheduleRefreshProps();
+      }, interval);
+    };
+
+    scheduleRefreshProps();
+
+    return () => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    };
+  }, [enabled, interval, refreshProps]);
+}

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -220,6 +220,7 @@ export {
 export type { Navigation } from "./contexts";
 export { DirtyFormContext, DirtyFormMarker } from "./dirtyform";
 export type { DirtyForm } from "./dirtyform";
+export { useAutoRefresh } from "./hooks";
 export { type NavigationController } from "./navigation";
 export type { Frame, Message, DjangoBridgeResponse as Response, Metadata };
 export { Link, BuildLinkElement, buildLinkElement };


### PR DESCRIPTION
This hook makes it easier to implement auto refresh, which is useful for implementing status pages.

For example:

```tsx
import { useAutoRefresh } from "@django-bridge/react";

function MyStatusPage({ status }) {

    // If status is pending, auto refresh every 2 seconds
    useAutoRefresh(status === "pending", 2000);

    return (
        <h1>The current status is: {status}</h1>
    )
}
```

Auto refreshes happen in the background, if the status changes, the component is re-rendered with the new status.