### PR TITLE
Fix links not responding after calling openOverlay on a view that doesn't support overlay

### DIFF
--- a/packages/react/src/components/Overlay.tsx
+++ b/packages/react/src/components/Overlay.tsx
@@ -14,7 +14,7 @@ export interface OverlayProps {
   config: Config;
   initialResponse: DjangoBridgeResponse;
   initialPath: string;
-  parentNavigationContoller: NavigationController;
+  parentNavigationController: NavigationController;
   render: (content: ReactNode) => ReactNode;
   requestClose: () => void;
   closeRequested: boolean;
@@ -26,7 +26,7 @@ export default function Overlay({
   config,
   initialResponse,
   initialPath,
-  parentNavigationContoller,
+  parentNavigationController,
   render,
   requestClose,
   closeRequested,
@@ -36,7 +36,7 @@ export default function Overlay({
   const { pushMessage } = React.useContext(MessagesContext);
 
   const navigationController = useNavigationController(
-    parentNavigationContoller,
+    parentNavigationController,
     config.unpack,
     initialResponse,
     initialPath,

--- a/packages/react/src/components/Overlay.tsx
+++ b/packages/react/src/components/Overlay.tsx
@@ -49,6 +49,9 @@ export default function Overlay({
         // Push any new messages from server
         messages.forEach(pushMessage);
       },
+      onEscalate: () => {
+        onCloseCompleted();
+      },
       onOverlayClose: (messages: Message[]) => {
         // Push any new messages from server
         messages.forEach(pushMessage);

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -177,7 +177,7 @@ export function App({ config, initialResponse }: AppProps): ReactElement {
               config={config}
               initialResponse={overlay.initialResponse}
               initialPath={overlay.initialPath}
-              parentNavigationContoller={navigationController}
+              parentNavigationController={navigationController}
               render={(content) => overlay.render(content)}
               requestClose={() => setOverlayCloseRequested(true)}
               closeRequested={overlayCloseRequested}

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -145,6 +145,11 @@ export function App({ config, initialResponse }: AppProps): ReactElement {
     renderOverlay: (content: ReactNode) => ReactNode,
     { onClose }: { onClose?: () => void } = {}
   ) => {
+    if (overlay) {
+      console.error("Unable to open overlay as an overlay is already open.");
+      return;
+    }
+
     navigationController.setIsNavigating(true);
 
     const initialOverlayResponse = await djangoGet(path, true);

--- a/packages/react/src/navigation.ts
+++ b/packages/react/src/navigation.ts
@@ -133,7 +133,8 @@ export function useNavigationController(
       response: DjangoBridgeResponse,
       path: string,
       pushState = true,
-      neverReload = false
+      neverReload = false,
+      initial = false
     ): Promise<void> => {
       if (response.action === "reload") {
         if (!parent) {
@@ -151,6 +152,11 @@ export function useNavigationController(
         // If this navigation controller is handling an overlay, make sure the response can be
         // loaded in a overlay. Otherwise, escalate it to parent
         if (parent && !response.overlay) {
+          if (initial) {
+            console.warn(
+              `openOverlay('${path}') returned a response that couldn't be rendered in an overlay.`
+            );
+          }
           return parent.handleResponse(response, path);
         }
 
@@ -305,7 +311,7 @@ export function useNavigationController(
   useEffect(() => {
     // Load initial response
     // eslint-disable-next-line no-void
-    void handleResponse(initialResponse, initialPath, false);
+    void handleResponse(initialResponse, initialPath, false, false, true);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {

--- a/packages/react/src/navigation.ts
+++ b/packages/react/src/navigation.ts
@@ -46,6 +46,7 @@ export function useNavigationController(
       newFrame: boolean,
       messages: Message[]
     ) => void;
+    onEscalate?: () => void;
     onOverlayClose?: (messages: Message[]) => void;
     onServerError?: (kind: "server" | "network") => void;
   } = {}
@@ -157,7 +158,13 @@ export function useNavigationController(
               `openOverlay('${path}') returned a response that couldn't be rendered in an overlay.`
             );
           }
-          return parent.handleResponse(response, path);
+          const r = parent.handleResponse(response, path);
+          // Call escalate callback, this will instantly close the overlay so the response can be rendered
+          // by the main window.
+          if (callbacks.onEscalate) {
+            callbacks.onEscalate();
+          }
+          return r;
         }
 
         // Unpack props and context


### PR DESCRIPTION
If you run `openOverlay` on a view that doesn't support running in overlays, there is a bit of behaviour built in to the navigation controller called "escalation". This allows the navigation controller of the overlay to pass the response to the main navigation controller for rendering.

This had a bug where if this occurred, the overlay wouldn't actually be closed (but also wouldn't be rendered so it's not clear what's going on).

When the user clicks another link that runs `openOverlay`, nothing happens as Django bridge still thinks the original overlay is open.

This is a pretty rare case as you wouldn't normally call `openOverlay` on a link that can't be rendered in an overlay. I've added a warning and fixed the behaviour.